### PR TITLE
Feature/overridable type resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target
 .settings
 .classpath
 .project
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,16 @@
 			<timezone>+5</timezone>
 		</developer>
 	</developers>
+	<contributors>
+		<contributor>
+			<name>Wolfgang Herget</name>
+			<id>wherget</id>
+			<email>wolfgang {dot} herget {at} dfki {dot} de</email>
+			<timezone>+1</timezone>
+			<organization>DFKI GmbH</organization>
+			<organizationUrl>http://www.dfki.de</organizationUrl>
+		</contributor>
+	</contributors>
 
 	<scm>
 		<connection>scm:git:git://github.com/cyberborean/rdfbeans.git</connection>

--- a/src/main/java/org/cyberborean/rdfbeans/RDFBeanManager.java
+++ b/src/main/java/org/cyberborean/rdfbeans/RDFBeanManager.java
@@ -702,7 +702,7 @@ public class RDFBeanManager {
 		return cls;
 	}
 
-	private Class<?> getBindingClassForType(URI rdfType) throws RDFBeanException, RepositoryException{
+	protected Class<?> getBindingClassForType(URI rdfType) throws RDFBeanException, RepositoryException{
 		Class cls = classCache.get(rdfType);
 		if (cls != null) {
 			return cls;


### PR DESCRIPTION
A very simple feature, just changing the visibility of getBindingClassForType.

The use-case is as follows: I want to unmarshal an RDF model into a class structure, but don't want to augment the model with `rdfbeans:bindingClass` properies. With this feature, I can write a subclass of RDFBeanManager that can look up binding classes using e.g. classpath scanning.

This PR touches upon issue #4, but is only a very small part of what is proposed there.
