### PR TITLE
Add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+sudo: false

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
 	<contributors>
 		<contributor>
 			<name>Wolfgang Herget</name>
-			<id>wherget</id>
 			<email>wolfgang {dot} herget {at} dfki {dot} de</email>
 			<timezone>+1</timezone>
 			<organization>DFKI GmbH</organization>


### PR DESCRIPTION
Since I already managed to get something pulled which maven doesn't build (but my local IntelliJ happily did 😠, sorry about that), here's a PR for a cheap travis configuration.

I think you'll appreciate having a little checkmark that tells you a given pull request doesn't foul the tests, or even the build. I think you still need to actually activate Travis CI integration, but in my experience that's extremely painless.

For convenience, I also added the commit that fixes my mistake to this PR.
