### PR TITLE
Enable Annotations "everywhere", clean up RDFBeanInfo a bit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
 		<rdf4j.version>2.0M1</rdf4j.version>
 		<slf4j.version>1.7.9</slf4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 	</properties>
 

--- a/src/main/java/org/cyberborean/rdfbeans/annotations/RDF.java
+++ b/src/main/java/org/cyberborean/rdfbeans/annotations/RDF.java
@@ -49,7 +49,7 @@ import java.lang.annotation.Target;
  * 
  */
 
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RDF {
 	/**

--- a/src/main/java/org/cyberborean/rdfbeans/annotations/RDFContainer.java
+++ b/src/main/java/org/cyberborean/rdfbeans/annotations/RDFContainer.java
@@ -57,7 +57,7 @@ import java.lang.annotation.Target;
  * 
  */
 
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RDFContainer {
 

--- a/src/main/java/org/cyberborean/rdfbeans/annotations/RDFNamespaces.java
+++ b/src/main/java/org/cyberborean/rdfbeans/annotations/RDFNamespaces.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * @author alex
  * 
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.PACKAGE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RDFNamespaces {
 

--- a/src/main/java/org/cyberborean/rdfbeans/annotations/RDFSubject.java
+++ b/src/main/java/org/cyberborean/rdfbeans/annotations/RDFSubject.java
@@ -67,7 +67,7 @@ import java.lang.annotation.Target;
  * 
  */
 
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RDFSubject {
 

--- a/src/main/java/org/cyberborean/rdfbeans/proxy/RDFBeanDelegator.java
+++ b/src/main/java/org/cyberborean/rdfbeans/proxy/RDFBeanDelegator.java
@@ -60,9 +60,9 @@ public class RDFBeanDelegator implements InvocationHandler {
     
     static {
 		try {
-		    hashCodeMethod = Object.class.getMethod("hashCode", null);
-		    equalsMethod = Object.class.getMethod("equals", new Class[] { Object.class });
-		    toStringMethod = Object.class.getMethod("toString", null);
+		    hashCodeMethod = Object.class.getMethod("hashCode");
+		    equalsMethod = Object.class.getMethod("equals", Object.class);
+		    toStringMethod = Object.class.getMethod("toString");
 	        } 
 		catch (NoSuchMethodException e) {
 		    throw new NoSuchMethodError(e.getMessage());

--- a/src/main/java/org/cyberborean/rdfbeans/reflect/AbstractRDFBeanProperty.java
+++ b/src/main/java/org/cyberborean/rdfbeans/reflect/AbstractRDFBeanProperty.java
@@ -29,7 +29,7 @@ import org.cyberborean.rdfbeans.exceptions.RDFBeanException;
  */
 public abstract class AbstractRDFBeanProperty {
 
-	private PropertyDescriptor propertyDescriptor;
+	protected PropertyDescriptor propertyDescriptor;
 
 	public AbstractRDFBeanProperty(PropertyDescriptor propertyDescriptor) {
 		this.propertyDescriptor = propertyDescriptor;

--- a/src/main/java/org/cyberborean/rdfbeans/reflect/RDFBeanInfo.java
+++ b/src/main/java/org/cyberborean/rdfbeans/reflect/RDFBeanInfo.java
@@ -171,18 +171,26 @@ public class RDFBeanInfo {
 	private void initNamespaces() throws RDFBeanValidationException {
 		List<RDFNamespaces> nsAnns = ReflectionUtil.getAllClassAnnotations(rdfBeanClass, RDFNamespaces.class);
 		for (RDFNamespaces nsAnn: nsAnns) {
-			for (String s: nsAnn.value()) {		
-				String[] ss = s.split("=", 2);
-				if (ss.length == 2) {
-					String prefix = ss[0].trim();
-					String value = ss[1].trim();
-					if (!namespaces.containsKey(prefix)) {
-						namespaces.put(prefix, value);
-					}
+			registerNamespaces(nsAnn);
+		}
+	}
+
+	private void registerNamespaces(RDFNamespaces annotation) throws RDFBeanValidationException {
+		for (String declaration: annotation.value()) {
+			String[] split = declaration.split("=", 2);
+			if (split.length == 2) {
+				String prefix = split[0].trim();
+				String value = split[1].trim();
+				if (namespaces.containsKey(prefix)) {
+					String currentValue = namespaces.get(prefix);
+					throw new RDFBeanValidationException("Tried to re-declare namespace: '" + prefix + "'," + 
+							"already defined as '" + currentValue + "'", rdfBeanClass);
+				} else {
+					namespaces.put(prefix, value);
 				}
-				else {
-					throw new RDFBeanValidationException("Wrong namespace declaration syntax: '" + s + "'", rdfBeanClass);
-				}
+			}
+			else {
+				throw new RDFBeanValidationException("Wrong namespace declaration syntax: '" + declaration + "'", rdfBeanClass);
 			}
 		}
 	}

--- a/src/main/java/org/cyberborean/rdfbeans/reflect/RDFBeanInfo.java
+++ b/src/main/java/org/cyberborean/rdfbeans/reflect/RDFBeanInfo.java
@@ -132,13 +132,15 @@ public class RDFBeanInfo {
 	}
 
 	private <T extends Annotation> T checkAnnotation(PropertyDescriptor pd, Class<T> theClass) {
-		T annotation;
+		T annotation = null;
 		Method getter = pd.getReadMethod();
 		if (getter != null) {
 			annotation = ReflectionUtil.getMethodAnnotation(getter, theClass);
 		} else {
 			Method setter = pd.getWriteMethod();
-			annotation = ReflectionUtil.getMethodAnnotation(setter, theClass);
+			if (setter != null) {
+				annotation = ReflectionUtil.getMethodAnnotation(setter, theClass);
+			}
 		}
 		if (annotation == null) {
 			// last resort: try an appropriately named field (as with e.g. Lombok)

--- a/src/main/java/org/cyberborean/rdfbeans/reflect/RDFBeanInfo.java
+++ b/src/main/java/org/cyberborean/rdfbeans/reflect/RDFBeanInfo.java
@@ -90,29 +90,7 @@ public class RDFBeanInfo {
 
 	private void introspect() throws RDFBeanValidationException {
 		initNamespaces();
-		RDFBean ann = ReflectionUtil.getClassAnnotation(rdfBeanClass, RDFBean.class);
-		if (ann != null) {			
-			String type = ann.value();
-			if (type != null) {
-				try {
-					rdfType = SimpleValueFactory.getInstance().createIRI(createUriString(type));
-				}
-				catch (IllegalArgumentException iae) {
-					throw new RDFBeanValidationException(
-							"RDF type parameter of " + RDFBean.class.getName() + " annotation on "
-							+ rdfBeanClass.getName() + " class must be an absolute valid URI: " + type, rdfBeanClass);
-				}
-			} else {
-				throw new RDFBeanValidationException(
-						"Required RDF type parameter is missing in "
-								+ RDFBean.class.getName() + " annotation on "
-								+ rdfBeanClass.getName() + " class", rdfBeanClass);
-			}
-		} else {
-			throw new RDFBeanValidationException("Not an RDFBean: "
-					+ RDFBean.class.getName() + " annotation is missing on "
-					+ rdfBeanClass.getName() + " class or its interfaces", rdfBeanClass);
-		}
+		initBeanType();
 		for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
 			Method getter = pd.getReadMethod();
 			if (getter != null) {
@@ -148,6 +126,32 @@ public class RDFBeanInfo {
 					}
 				}
 			}			
+		}
+	}
+
+	private void initBeanType() throws RDFBeanValidationException {
+		RDFBean ann = ReflectionUtil.getClassAnnotation(rdfBeanClass, RDFBean.class);
+		if (ann == null) {
+			throw new RDFBeanValidationException("Not an RDFBean: "
+					+ RDFBean.class.getName() + " annotation is missing on "
+					+ rdfBeanClass.getName() + " class or its interfaces", rdfBeanClass);
+		} else {
+			String type = ann.value();
+			if (type != null) {
+				try {
+					rdfType = SimpleValueFactory.getInstance().createIRI(createUriString(type));
+				}
+				catch (IllegalArgumentException iae) {
+					throw new RDFBeanValidationException(
+							"RDF type parameter of " + RDFBean.class.getName() + " annotation on "
+									+ rdfBeanClass.getName() + " class must be an absolute valid URI: " + type, rdfBeanClass);
+				}
+			} else {
+				throw new RDFBeanValidationException(
+						"Required RDF type parameter is missing in "
+								+ RDFBean.class.getName() + " annotation on "
+								+ rdfBeanClass.getName() + " class", rdfBeanClass);
+			}
 		}
 	}
 

--- a/src/main/java/org/cyberborean/rdfbeans/reflect/RDFBeanInfo.java
+++ b/src/main/java/org/cyberborean/rdfbeans/reflect/RDFBeanInfo.java
@@ -169,6 +169,10 @@ public class RDFBeanInfo {
 	}
 
 	private void initNamespaces() throws RDFBeanValidationException {
+		RDFNamespaces packageNamespaces = ReflectionUtil.getPackageAnnotation(rdfBeanClass, RDFNamespaces.class);
+		if (packageNamespaces != null) {
+			registerNamespaces(packageNamespaces);
+		}
 		List<RDFNamespaces> nsAnns = ReflectionUtil.getAllClassAnnotations(rdfBeanClass, RDFNamespaces.class);
 		for (RDFNamespaces nsAnn: nsAnns) {
 			registerNamespaces(nsAnn);

--- a/src/main/java/org/cyberborean/rdfbeans/reflect/RDFBeanInfo.java
+++ b/src/main/java/org/cyberborean/rdfbeans/reflect/RDFBeanInfo.java
@@ -19,6 +19,7 @@ import java.beans.MethodDescriptor;
 import java.beans.PropertyDescriptor;
 import java.beans.SimpleBeanInfo;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -138,6 +139,19 @@ public class RDFBeanInfo {
 		} else {
 			Method setter = pd.getWriteMethod();
 			annotation = ReflectionUtil.getMethodAnnotation(setter, theClass);
+		}
+		if (annotation == null) {
+			// last resort: try an appropriately named field (as with e.g. Lombok)
+			try {
+				Field field = rdfBeanClass.getDeclaredField(pd.getName());
+				if (pd.getPropertyType().isAssignableFrom(field.getType())) {
+					// field might be more specific, but needs to be compatible
+					annotation = field.getDeclaredAnnotation(theClass);
+				}
+			} catch (NoSuchFieldException e) {
+				// no luck then
+				return null;
+			}
 		}
 		return annotation;
 	}

--- a/src/main/java/org/cyberborean/rdfbeans/reflect/ReflectionUtil.java
+++ b/src/main/java/org/cyberborean/rdfbeans/reflect/ReflectionUtil.java
@@ -53,20 +53,14 @@ public class ReflectionUtil {
 		}
 	}
 	
-	public static Annotation getMethodAnnotation(Method method, Class... annotationTypes) {
-		Annotation ann = null;
-		for (Class annType: annotationTypes) {
-			ann = method.getAnnotation(annType);
-			if (ann != null) {
-				return ann;
-			}
-		}
+	public static <T extends Annotation> T getMethodAnnotation(Method method, Class<T> annotationType) {
+		T ann = method.getAnnotation(annotationType);
 		if (ann == null) {
 			// Inspect interface methods
 			for (Class iface: method.getDeclaringClass().getInterfaces()) {
 				for (Method otherMethod: iface.getMethods()) {
 					if (isMatchingMethodSignatures(method, otherMethod)) {
-						return getMethodAnnotation(otherMethod, annotationTypes);
+						return getMethodAnnotation(otherMethod, annotationType);
 					}
 				}
 			}
@@ -100,6 +94,4 @@ public class ReflectionUtil {
 		}
 		return allInterfaces.toArray(new Class[allInterfaces.size()]);
 	}
-	}
-
 }

--- a/src/main/java/org/cyberborean/rdfbeans/reflect/ReflectionUtil.java
+++ b/src/main/java/org/cyberborean/rdfbeans/reflect/ReflectionUtil.java
@@ -22,7 +22,7 @@ import java.util.List;
  *
  */
 public class ReflectionUtil {
-	
+
 	public static <A extends Annotation> A getClassAnnotation(Class<?> cls, Class<A> annotationType) {
 		A ann = cls.getAnnotation(annotationType);
 		if (ann == null) {
@@ -36,23 +36,23 @@ public class ReflectionUtil {
 		}
 		return ann;
 	}
-	
+
 	public static <A extends Annotation> List<A> getAllClassAnnotations(Class<?> cls, Class<A> annotationType) {
 		List<A> results = new ArrayList<A>();
 		findClassAnnotations(cls, annotationType, results);
 		return results;
 	}
-	
+
 	private static <A extends Annotation> void findClassAnnotations(Class<?> cls, Class<A> annotationType, List<A> list) {
 		A ann =  cls.getAnnotation(annotationType);
 		if (ann != null) {
 			list.add(ann);
-		}		
+		}
 		for (Class iface: cls.getInterfaces()) {
 			findClassAnnotations(iface, annotationType, list);
 		}
 	}
-	
+
 	public static <T extends Annotation> T getMethodAnnotation(Method method, Class<T> annotationType) {
 		T ann = method.getAnnotation(annotationType);
 		if (ann == null) {

--- a/src/main/java/org/cyberborean/rdfbeans/reflect/ReflectionUtil.java
+++ b/src/main/java/org/cyberborean/rdfbeans/reflect/ReflectionUtil.java
@@ -68,6 +68,11 @@ public class ReflectionUtil {
 		return ann;
 	}
 
+	public static <A extends Annotation> A getPackageAnnotation(Class<?> cls, Class<A> annotationType) {
+		Package p = cls.getPackage();
+		return p == null ? null : p.getAnnotation(annotationType);
+	}
+
 	/**
 	 * @param method
 	 * @param otherMethod

--- a/src/main/java/org/cyberborean/rdfbeans/reflect/ReflectionUtil.java
+++ b/src/main/java/org/cyberborean/rdfbeans/reflect/ReflectionUtil.java
@@ -23,12 +23,12 @@ import java.util.List;
  */
 public class ReflectionUtil {
 	
-	public static <A extends Annotation> A getClassAnnotation(Class cls, Class<A> annotationType) {
-		A ann =  (A) cls.getAnnotation(annotationType);
+	public static <A extends Annotation> A getClassAnnotation(Class<?> cls, Class<A> annotationType) {
+		A ann = cls.getAnnotation(annotationType);
 		if (ann == null) {
 			// No class annotation present, inspect interfaces
-			for (Class iface: cls.getInterfaces()) {
-				ann = (A) iface.getAnnotation(annotationType);
+			for (Class<?> iface: cls.getInterfaces()) {
+				ann = iface.getAnnotation(annotationType);
 				if (ann != null) {
 					break;
 				}
@@ -37,14 +37,14 @@ public class ReflectionUtil {
 		return ann;
 	}
 	
-	public static <A extends Annotation> List<A> getAllClassAnnotations(Class cls, Class<A> annotationType) {
+	public static <A extends Annotation> List<A> getAllClassAnnotations(Class<?> cls, Class<A> annotationType) {
 		List<A> results = new ArrayList<A>();
 		findClassAnnotations(cls, annotationType, results);
-		return results;		
+		return results;
 	}
 	
-	private static void findClassAnnotations(Class cls, Class annotationType, List list) {
-		Annotation ann =  cls.getAnnotation(annotationType);
+	private static <A extends Annotation> void findClassAnnotations(Class<?> cls, Class<A> annotationType, List<A> list) {
+		A ann =  cls.getAnnotation(annotationType);
 		if (ann != null) {
 			list.add(ann);
 		}		
@@ -90,15 +90,16 @@ public class ReflectionUtil {
 			Arrays.hashCode(m.getParameterTypes());
 	}
 	
-	public static Class[] getAllInterfaces(Class[] interfaces) {
-		List allInterfaces = new ArrayList();
-        for (int i = 0; i < interfaces.length; i++) {
-            allInterfaces.add(interfaces[i]);
-            allInterfaces.addAll(
-                Arrays.asList(
-                    getAllInterfaces(interfaces[i].getInterfaces())));
-        }
-        return (Class[]) allInterfaces.toArray(new Class[allInterfaces.size()]);
+	public static Class<?>[] getAllInterfaces(Class[] interfaces) {
+		List<Class<?>> allInterfaces = new ArrayList<>();
+		for (int i = 0; i < interfaces.length; i++) {
+			allInterfaces.add(interfaces[i]);
+			allInterfaces.addAll(
+				Arrays.asList(
+					getAllInterfaces(interfaces[i].getInterfaces())));
+		}
+		return allInterfaces.toArray(new Class[allInterfaces.size()]);
+	}
 	}
 
 }

--- a/src/test/java/org/cyberborean/rdfbeans/datatype/DatatypeTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/datatype/DatatypeTest.java
@@ -37,16 +37,15 @@ public class DatatypeTest extends RDFBeansTestBase {
     	object.setUriValue(URI.create("http://rdfbeans.sourceforge.net"));
     	int[] array = new int[] {0, 1, 2, 3, 4};
     	object.setArrayValue(array);
-    	object.setListValue(Arrays.asList(new String[] {"a", "b", "c", "d"}));
-    	Set set = new HashSet(3);
+        object.setListValue(Arrays.asList(new Object[] {"a", "b", "c", "d"}));
+        Set<Object> set = new HashSet<>(3);
     	set.add("foo"); set.add("bar"); set.add("baz");
     	object.setSetValue(set);
-    	SortedSet sortedSet = new TreeSet();
+        SortedSet<Object> sortedSet = new TreeSet<>();
     	sortedSet.addAll(set);
-    	object.setSortedSetValue(sortedSet);    	
-    	
-        resource = manager.add(object);        
-    }    
+        object.setSortedSetValue(sortedSet);
+        resource = manager.add(object);
+    }
     
     @Test
     public void test() throws Exception {               

--- a/src/test/java/org/cyberborean/rdfbeans/datatype/ListTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/datatype/ListTest.java
@@ -85,7 +85,7 @@ public class ListTest {
     @Test
     public void encodeHeadTailList() throws RepositoryException, RDFBeanException, URISyntaxException {
         DatatypeTestClass data = new DatatypeTestClass();
-        List<URI> elements = Arrays.asList(new URI("http://example.com/first"), new URI("http://example.com/last"));
+        List<Object> elements = Arrays.asList((Object)new URI("http://example.com/first"), (Object)new URI("http://example.com/last"));
         data.setHeadTailList(elements);
         Resource marshaled = manager.add(data);
         RepositoryConnection checkConn = repo.getConnection();

--- a/src/test/java/org/cyberborean/rdfbeans/test/entities/DatatypeTestClass.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/entities/DatatypeTestClass.java
@@ -40,10 +40,10 @@ public class DatatypeTestClass {
 	java.net.URI uriValue;
 	
 	int[] arrayValue;
-	List listValue;
-	Set setValue;
-	SortedSet sortedSetValue;
-	List headTailList;
+	List<Object> listValue;
+	Set<Object> setValue;
+	SortedSet<Object> sortedSetValue;
+	List<Object> headTailList;
 
 	@RDFSubject
 	public String getID() {
@@ -111,25 +111,25 @@ public class DatatypeTestClass {
 	}
 	
 	@RDF(value="http://cyberborean.org/rdfbeans/2.0/test/datatype/list")
-	public List getListValue() {
+	public List<Object>  getListValue() {
 		return listValue;
 	}
 
 	@RDF(value="http://cyberborean.org/rdfbeans/2.0/test/datatype/set")
 	@RDFContainer(ContainerType.BAG)
-	public Set getSetValue() {
+	public Set<Object>  getSetValue() {
 		return setValue;
 	}
 	
 	@RDF(value="http://cyberborean.org/rdfbeans/2.0/test/datatype/sortedSet")
 	@RDFContainer(ContainerType.ALT)
-	public SortedSet getSortedSetValue() {
+	public SortedSet<Object>  getSortedSetValue() {
 		return sortedSetValue;
 	}
 
 	@RDF(value="http://cyberborean.org/rdfbeans/2.0/test/datatype/headTailList")
 	@RDFContainer(ContainerType.LIST)
-	public List getHeadTailListValue() {
+	public List<Object>  getHeadTailListValue() {
 		return headTailList;
 	}
 
@@ -174,15 +174,15 @@ public class DatatypeTestClass {
 	public void setArrayValue(int n, int value) {
 		this.arrayValue[n] = value;
 	}
-	public void setListValue(List listValue) {
+	public void setListValue(List<Object> listValue) {
 		this.listValue = listValue;
 	}
-	public void setSetValue(Set setValue) {
+	public void setSetValue(Set<Object> setValue) {
 		this.setValue = setValue;
 	}
-	public void setSortedSetValue(SortedSet sortedSetValue) {
+	public void setSortedSetValue(SortedSet<Object> sortedSetValue) {
 		this.sortedSetValue = sortedSetValue;
 	}
-	public void setHeadTailList(List headTailList) { this.headTailList = headTailList; }
+	public void setHeadTailList(List<Object> headTailList) { this.headTailList = headTailList; }
 
 }

--- a/src/test/java/org/cyberborean/rdfbeans/test/examples/ExampleClassTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/examples/ExampleClassTest.java
@@ -109,11 +109,11 @@ public class ExampleClassTest extends RDFBeansTestBase {
     @Test
     public void testGetAll() throws Exception {                
         CloseableIteration<Person, Exception> iter = manager.getAll(Person.class);
-        Set s = new HashSet();
+        Set<Person> s = new HashSet<>();
         while (iter.hasNext()) {
             Object o = iter.next();
             assertTrue(o instanceof Person);
-            s.add(o);
+            s.add((Person)o);
         }
         iter.close();
         assertEquals(s.size(), 3);

--- a/src/test/java/org/cyberborean/rdfbeans/test/foafexample/FOAFExampleTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/foafexample/FOAFExampleTest.java
@@ -129,11 +129,11 @@ public class FOAFExampleTest extends RDFBeansTestBase {
     @Test
     public void testGetAll() throws Exception {                
     	CloseableIteration<Person, Exception> iter = manager.getAll(Person.class);
-        Set s = new HashSet();
+        Set<Person> s = new HashSet<>();
         while (iter.hasNext()) {
             Object o = iter.next();
             assertTrue(o instanceof Person);
-            s.add(o);
+            s.add((Person)o);
         }
         iter.close();
         assertEquals(s.size(), 3);

--- a/src/test/java/org/cyberborean/rdfbeans/test/reflect/RDFBeanInfoTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/reflect/RDFBeanInfoTest.java
@@ -35,11 +35,13 @@ public class RDFBeanInfoTest {
 	public void shouldReadNamespaces() {
 		Map<String, String> namespaces = info.getRDFNamespaces();
 		assertThat(namespaces, notNullValue());
-		assertThat(namespaces.size(), is(2));
+		assertThat(namespaces.size(), is(3));
 		assertThat(namespaces.containsKey("ex"), is(true));
 		assertThat(namespaces.get("ex"), equalTo("http://example.org/"));
 		assertThat(namespaces.containsKey("ex2"), is(true));
 		assertThat(namespaces.get("ex2"), equalTo("http://example.com/withSpaces#"));
+		assertThat(namespaces.containsKey("pkg"), is(true));
+		assertThat(namespaces.get("pkg"), equalTo("http://example.com/package-ns#"));
 	}
 
 	@Test

--- a/src/test/java/org/cyberborean/rdfbeans/test/reflect/RDFBeanInfoTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/reflect/RDFBeanInfoTest.java
@@ -22,6 +22,11 @@ public class RDFBeanInfoTest {
 		@RDF("ex2:test")
 		public abstract Object getTest();
 		public abstract void setTest(Object test);
+
+		@RDF("pkg:field")
+		private Object field;
+		public abstract Object getField();
+		public abstract void setField(Object field);
 	}
 
 	private static RDFBeanInfo info;
@@ -54,5 +59,11 @@ public class RDFBeanInfoTest {
 	public void shouldApplyNamespaceToProperty() {
 		IRI expected = SimpleValueFactory.getInstance().createIRI("http://example.com/withSpaces#test");
 		assertThat(info.getProperty(expected), notNullValue());
+	}
+
+	@Test
+	public void annotationMayBeOnField() {
+		IRI field = SimpleValueFactory.getInstance().createIRI("http://example.com/package-ns#field");
+		assertThat(info.getProperty(field), notNullValue());
 	}
 }

--- a/src/test/java/org/cyberborean/rdfbeans/test/reflect/package-info.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/reflect/package-info.java
@@ -1,0 +1,4 @@
+@RDFNamespaces("pkg = http://example.com/package-ns#")
+package org.cyberborean.rdfbeans.test.reflect;
+
+import org.cyberborean.rdfbeans.annotations.RDFNamespaces;


### PR DESCRIPTION
This fixes #11, enabling:
- `@RDF` and `@RDFSubject` on either
  - Setter
  - Getter
  - Field
- `@RDFNamespaces` on a Package

(as witnessed by the included unit test)

This PR furthermore adds a few Generic specifiers (usually `<?>`) and drops a few explicit casts (which were not needed anymore after improving the type information).
