### PR TITLE
Try binding resolution for other types a resource might have.

### DIFF
--- a/src/main/java/org/cyberborean/rdfbeans/RDFBeanManager.java
+++ b/src/main/java/org/cyberborean/rdfbeans/RDFBeanManager.java
@@ -696,9 +696,8 @@ public class RDFBeanManager {
 
 	private Class<?> getBindingClass(Resource r) throws RDFBeanException, RepositoryException {		
 		Class<?> cls = null;
-		CloseableIteration<Statement, RepositoryException> ts = null;
-		try {
-			ts = conn.getStatements(r, RDF.TYPE, null, false);
+		try (CloseableIteration<Statement, RepositoryException> ts =
+				conn.getStatements(r, RDF.TYPE, null, false)) {
 			if (ts.hasNext()) {
 				Value type = ts.next().getObject();
 				if (type instanceof IRI) {
@@ -707,11 +706,6 @@ public class RDFBeanManager {
 				else {
 					throw new RDFBeanException("Resource " + r.stringValue() + " has invalid RDF type " + type.stringValue() + ": not a URI");
 				}
-			}
-		}
-		finally {
-			if (ts != null) {
-				ts.close();
 			}
 		}
 		return cls;

--- a/src/main/java/org/cyberborean/rdfbeans/RDFBeanManager.java
+++ b/src/main/java/org/cyberborean/rdfbeans/RDFBeanManager.java
@@ -698,7 +698,7 @@ public class RDFBeanManager {
 		Class<?> cls = null;
 		try (CloseableIteration<Statement, RepositoryException> ts =
 				conn.getStatements(r, RDF.TYPE, null, false)) {
-			if (ts.hasNext()) {
+			while (cls == null && ts.hasNext()) {
 				Value type = ts.next().getObject();
 				if (type instanceof IRI) {
 					cls = getBindingClassForType((IRI)type);

--- a/src/test/java/org/cyberborean/rdfbeans/datatype/MultipleTypeTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/datatype/MultipleTypeTest.java
@@ -1,0 +1,58 @@
+package org.cyberborean.rdfbeans.datatype;
+
+import org.cyberborean.rdfbeans.RDFBeanManager;
+import org.cyberborean.rdfbeans.exceptions.RDFBeanException;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class MultipleTypeTest {
+	private SailRepository repo;
+	protected List<IRI> triedTypes = new ArrayList<>();
+	private RDFBeanManager manager;
+
+	private class CheckBeanManager extends RDFBeanManager {
+		public CheckBeanManager(RepositoryConnection conn) {
+			super(conn);
+		}
+
+		@Override
+		protected Class<?> getBindingClassForType(IRI rdfType) throws RDFBeanException, RepositoryException {
+			triedTypes.add(rdfType);
+			return super.getBindingClassForType(rdfType);
+		}
+	}
+
+	@Before
+	public void setupManager() throws Exception {
+		repo = new SailRepository(new MemoryStore());
+		repo.initialize();
+		RepositoryConnection initialFillConn = repo.getConnection();
+		initialFillConn.add(getClass().getResourceAsStream("listUnmarshal.ttl"), "", RDFFormat.TURTLE);
+		initialFillConn.close();
+		manager = new CheckBeanManager(repo.getConnection());
+	}
+
+	@Test
+	public void shouldTryAllTypes() {
+		triedTypes.clear();
+		try {
+			manager.get(repo.getValueFactory().createIRI("http://example.com/list/dataClass"));
+			throw new AssertionError("Should have thrown by now");
+		} catch (RDFBeanException e) {
+			assert(e.getMessage().startsWith("Cannot detect a binding class"));
+		}
+		assertThat(triedTypes.size(), is(2));
+	}
+}

--- a/src/test/resources/org/cyberborean/rdfbeans/datatype/listUnmarshal.ttl
+++ b/src/test/resources/org/cyberborean/rdfbeans/datatype/listUnmarshal.ttl
@@ -3,6 +3,7 @@
 
 ex:dataClass
     a dt:DatatypeTestClass;
+    a ex:SecondaryClass;
     dt:list (
         ex:first
         ex:second


### PR DESCRIPTION
This PR fixes #18. So long as no matching binding has been found, keep trying to find one for remaining `rdf:type`s of the resource in question.

There might be cases where one binding is to be preferred over another out of multiple available, and this solution only considers the first one it finds. I still think this is better then not finding a binding at all.
