### PR TITLE
Update to current RDF4J version, removing transitive vulnerability.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,9 @@
 	</distributionManagement>
 
 	<properties>
-		<rdf4j.version>4.3.8</rdf4j.version>
-		<slf4j.version>2.0.9</slf4j.version>
+		<!-- rdf4j.version>4.3.8</rdf4j.version -->
+		<rdf4j.version>5.0.2</rdf4j.version>
+		<slf4j.version>2.0.16</slf4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
@@ -133,7 +134,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.7</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -144,7 +145,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.10.3</version>
+					<version>3.10.1</version>
 					<configuration>
 						<failOnError>true</failOnError>
 						<doclet>ch.raffael.doclets.pegdown.PegdownDoclet</doclet>
@@ -199,6 +200,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.10.1</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -299,12 +301,12 @@
 		</profile>
 	</profiles>
 
-	<reporting>
+	<!-- reporting>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>2.9</version>
+				<version>3.10.1</version>
 				<reportSets>
 					<reportSet>
 						<reports>
@@ -323,7 +325,7 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 			</plugin>
 		</plugins>
-	</reporting>
+	</ reporting-->
 
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -148,12 +148,12 @@
 					<version>3.10.1</version>
 					<configuration>
 						<failOnError>true</failOnError>
-						<doclet>ch.raffael.doclets.pegdown.PegdownDoclet</doclet>
+						<!-- doclet>ch.raffael.doclets.pegdown.PegdownDoclet</doclet>
 						<docletArtifact>
 							<groupId>ch.raffael.pegdown-doclet</groupId>
 							<artifactId>pegdown-doclet</artifactId>
 							<version>1.3</version>
-						</docletArtifact>
+						</docletArtifact -->
 						<useStandardDocletOptions>true</useStandardDocletOptions>
 					</configuration>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
 	</distributionManagement>
 
 	<properties>
-		<!-- rdf4j.version>4.3.8</rdf4j.version -->
 		<rdf4j.version>5.0.2</rdf4j.version>
 		<slf4j.version>2.0.16</slf4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
 		</profile>
 	</profiles>
 
-	<!-- reporting>
+	<reporting>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -325,7 +325,7 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 			</plugin>
 		</plugins>
-	</ reporting-->
+	</reporting>
 
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
 	</distributionManagement>
 
 	<properties>
-		<rdf4j.version>2.5.2</rdf4j.version>
-		<slf4j.version>1.7.9</slf4j.version>
+		<rdf4j.version>4.3.8</rdf4j.version>
+		<slf4j.version>2.0.9</slf4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
@@ -196,7 +196,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
@@ -209,7 +208,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>

--- a/src/main/java/org/cyberborean/rdfbeans/RDFBeanManagerContext.java
+++ b/src/main/java/org/cyberborean/rdfbeans/RDFBeanManagerContext.java
@@ -238,57 +238,63 @@ public class RDFBeanManagerContext {
 	 *             If the class is not a valid RDFBean class
 	 * @throws RepositoryException
 	 */
-	public <T> CloseableIteration<T, Exception> getAll(final Class<T> rdfBeanClass)
+	public <T> CloseableIteration<T> getAll(final Class<T> rdfBeanClass)
 			throws RDFBeanException, RepositoryException {
+	//public <T> CloseableIteration<T, Exception> getAll(final Class<T> rdfBeanClass)
+	//		throws RDFBeanException, RepositoryException {
 		RDFBeanInfo rbi = RDFBeanInfo.get(rdfBeanClass);
 		IRI type = rbi.getRDFType();
 		if (type == null) {
-			return new CloseableIteration<T, Exception>() {
+			//return new CloseableIteration<T, Exception>() {
+			return new CloseableIteration<T>() {
 
 				@Override
-				public boolean hasNext() throws Exception {
+				public boolean hasNext() {
 					return false;
 				}
 
 				@Override
-				public T next() throws Exception {
+				public T next() {
 					return null;
 				}
 
 				@Override
-				public void remove() throws Exception {
+				public void remove() {
 					throw new UnsupportedOperationException();
 				}
 
 				@Override
-				public void close() throws Exception {
+				public void close() {
 				}
 
 			};
 		}
 
-		final CloseableIteration<Statement, RepositoryException> sts = connectionPool.getConnection()
+		final CloseableIteration<Statement> sts = connectionPool.getConnection()
 				.getStatements(null, RDF.TYPE, type, false, (IRI)context);
+		//final CloseableIteration<Statement, RepositoryException> sts = connectionPool.getConnection()
+		//		.getStatements(null, RDF.TYPE, type, false, (IRI)context);
 
-		return new CloseableIteration<T, Exception>() {
+		//return new CloseableIteration<T, Exception>() {
+		return new CloseableIteration<T>() {
 
 			@Override
-			public boolean hasNext() throws Exception {
+			public boolean hasNext() {
 				return sts.hasNext();
 			}
 
 			@Override
-			public T next() throws Exception {
+			public T next() {
 				return _get(sts.next().getSubject(), rdfBeanClass);
 			}
 
 			@Override
-			public void remove() throws Exception {
+			public void remove() {
 				throw new UnsupportedOperationException();
 			}
 
 			@Override
-			public void close() throws Exception {
+			public void close() {
 				sts.close();
 			}
 		};

--- a/src/main/java/org/cyberborean/rdfbeans/RDFBeanManagerContext.java
+++ b/src/main/java/org/cyberborean/rdfbeans/RDFBeanManagerContext.java
@@ -322,8 +322,6 @@ public class RDFBeanManagerContext {
 	 * 
 	 * @param r
 	 *            Resource IRI or BNode
-	 * @param context
-	 *            RDF4J context
 	 * @return true, if the model contains the statements with the given
 	 *         resource subject and RDF type of that resource matches one
 	 *         specified in {@link RDFBean} annotation of the given class.
@@ -686,7 +684,7 @@ public class RDFBeanManagerContext {
 	 * 
 	 * @return the current ClassLoader instance
 	 * 
-	 * @see setClassLoader(ClassLoader)
+	 * see setClassLoader(ClassLoader)
 	 */
 	public ClassLoader getClassLoader() {
 		return unmarshaller.getClassLoader();
@@ -697,7 +695,7 @@ public class RDFBeanManagerContext {
 	 * 
 	 * @return the datatypeMapper
 	 * 
-	 * @see setDatatypeMapper(DatatypeMapper)
+	 * see setDatatypeMapper(DatatypeMapper)
 	 */
 	public DatatypeMapper getDatatypeMapper() {
 		return marshaller.getDatatypeMapper();

--- a/src/main/java/org/cyberborean/rdfbeans/RDFBeanManagerContext.java
+++ b/src/main/java/org/cyberborean/rdfbeans/RDFBeanManagerContext.java
@@ -21,7 +21,7 @@ import org.cyberborean.rdfbeans.proxy.ProxyListener;
 import org.cyberborean.rdfbeans.reflect.RDFBeanInfo;
 import org.cyberborean.rdfbeans.reflect.SubjectProperty;
 import org.cyberborean.rdfbeans.util.LockKeeper;
-import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;

--- a/src/main/java/org/cyberborean/rdfbeans/annotations/RDFNamespaces.java
+++ b/src/main/java/org/cyberborean/rdfbeans/annotations/RDFNamespaces.java
@@ -5,29 +5,29 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- *
- * Applied to: Class or interface declaration <br>
- * Value: String or String array (required)
- *
- *
- * `@RDFNamespaces` annotation specifies one or more RDF namespace prefixes in
- * the format `<prefix> = <uri>`
- *
- * Examples:
- * ---------
- * ```
- * {@literal @}RDFNamespaces("owl = http://www.w3.org/2002/07/owl#");
- * ```
- *
- * ```
- * {@literal @}RDFNamespaces({
- *    "foaf = http://xmlns.com/foaf/0.1/",
- *    "persons = http://rdfbeans.viceversatech.com/test-ontology/persons/"
- *  });
- * ``` 
- *
- */
+ ///
+ ///
+ /// Applied to: Class or interface declaration <br>
+ /// Value: String or String array (required)
+ ///
+ ///
+ /// `@RDFNamespaces` annotation specifies one or more RDF namespace prefixes in
+ /// the format `<prefix> = <uri>`
+ ///
+ /// Examples:
+ /// ---------
+ /// ```
+ /// {@literal @}RDFNamespaces("owl = http://www.w3.org/2002/07/owl#");
+ /// ```
+ ///
+ /// ```
+ /// {@literal @}RDFNamespaces({
+ ///    "foaf = http://xmlns.com/foaf/0.1/",
+ ///    "persons = http://rdfbeans.viceversatech.com/test-ontology/persons/"
+ ///  });
+ /// ``` 
+ ///
+ ///
 @Target({ElementType.TYPE, ElementType.PACKAGE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RDFNamespaces {

--- a/src/main/java/org/cyberborean/rdfbeans/datatype/DateUtils.java
+++ b/src/main/java/org/cyberborean/rdfbeans/datatype/DateUtils.java
@@ -14,6 +14,7 @@ public class DateUtils {
 	static final SimpleDateFormat ISO8601DateFormat;
     static final SimpleDateFormat ISO8601DateFormat2; 
     static final SimpleDateFormat ISO8601DateFormat3; 
+    static final SimpleDateFormat ISO8601DateOnlyFormat;
     
     static final DateFormat[] dateformats;
     
@@ -31,10 +32,15 @@ public class DateUtils {
                     .getDateTimeInstance();
         	ISO8601DateFormat3.applyPattern("yyyy-MM-dd'T'HH:mmX");
         	
+        	ISO8601DateOnlyFormat = (SimpleDateFormat) DateFormat
+                    .getDateTimeInstance();
+        	ISO8601DateOnlyFormat.applyPattern("yyyy-MM-dd");
+        	
         	dateformats = new DateFormat[] {
         			ISO8601DateFormat, 
         			ISO8601DateFormat2, 
         			ISO8601DateFormat3, 
+        			ISO8601DateOnlyFormat,
         			DateFormat.getInstance(), 
         			DateFormat.getDateInstance()
         	};

--- a/src/main/java/org/cyberborean/rdfbeans/datatype/DefaultDatatypeMapper.java
+++ b/src/main/java/org/cyberborean/rdfbeans/datatype/DefaultDatatypeMapper.java
@@ -45,6 +45,7 @@ public class DefaultDatatypeMapper implements DatatypeMapper {
 		DATATYPE_MAP.put(Short.class, XMLSchema.SHORT);
 		DATATYPE_MAP.put(BigDecimal.class, XMLSchema.DECIMAL);
 		DATATYPE_MAP.put(java.net.URI.class, XMLSchema.ANYURI);
+		DATATYPE_MAP.put(java.time.LocalDate.class, XMLSchema.DATE);
 		
 		// custom datatypes
 		DATATYPE_MAP.put(Character.class, Java.CHAR);
@@ -98,6 +99,10 @@ public class DefaultDatatypeMapper implements DatatypeMapper {
 		}
 		else if (XMLSchema.DATETIME.equals(dt)) {
 			return l.calendarValue().toGregorianCalendar().getTime();
+		} 
+		else if (XMLSchema.DATE.equals(dt)) {
+			// TODO: Confirm this works for LocalDate
+			return l.temporalAccessorValue();
 		} 
 		else if (Java.CHAR.equals(dt)) {
 			String s = l.stringValue();

--- a/src/main/java/org/cyberborean/rdfbeans/datatype/DefaultDatatypeMapper.java
+++ b/src/main/java/org/cyberborean/rdfbeans/datatype/DefaultDatatypeMapper.java
@@ -1,6 +1,7 @@
 package org.cyberborean.rdfbeans.datatype;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -8,7 +9,7 @@ import java.util.Map;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 
 
 /**
@@ -34,18 +35,19 @@ public class DefaultDatatypeMapper implements DatatypeMapper {
 	static {
 		
 		// standard XML-Schema datatypes
-		DATATYPE_MAP.put(String.class, XMLSchema.STRING);
-		DATATYPE_MAP.put(Integer.class, XMLSchema.INT);
-		DATATYPE_MAP.put(Date.class, XMLSchema.DATETIME);
-		DATATYPE_MAP.put(Boolean.class, XMLSchema.BOOLEAN);
-		DATATYPE_MAP.put(Float.class, XMLSchema.FLOAT);
-		DATATYPE_MAP.put(Double.class, XMLSchema.DOUBLE);
-		DATATYPE_MAP.put(Byte.class, XMLSchema.BYTE);
-		DATATYPE_MAP.put(Long.class, XMLSchema.LONG);
-		DATATYPE_MAP.put(Short.class, XMLSchema.SHORT);
-		DATATYPE_MAP.put(BigDecimal.class, XMLSchema.DECIMAL);
-		DATATYPE_MAP.put(java.net.URI.class, XMLSchema.ANYURI);
-		DATATYPE_MAP.put(java.time.LocalDate.class, XMLSchema.DATE);
+		DATATYPE_MAP.put(String.class, XSD.STRING);
+		DATATYPE_MAP.put(Integer.class, XSD.INT);
+		DATATYPE_MAP.put(Date.class, XSD.DATETIME);
+		DATATYPE_MAP.put(LocalDate.class, XSD.DATE);
+		DATATYPE_MAP.put(Boolean.class, XSD.BOOLEAN);
+		DATATYPE_MAP.put(Float.class, XSD.FLOAT);
+		DATATYPE_MAP.put(Double.class, XSD.DOUBLE);
+		DATATYPE_MAP.put(Byte.class, XSD.BYTE);
+		DATATYPE_MAP.put(Long.class, XSD.LONG);
+		DATATYPE_MAP.put(Short.class, XSD.SHORT);
+		DATATYPE_MAP.put(BigDecimal.class, XSD.DECIMAL);
+		DATATYPE_MAP.put(java.net.URI.class, XSD.ANYURI);
+		DATATYPE_MAP.put(java.time.LocalDate.class, XSD.DATE);
 		
 		// custom datatypes
 		DATATYPE_MAP.put(Character.class, Java.CHAR);
@@ -67,42 +69,41 @@ public class DefaultDatatypeMapper implements DatatypeMapper {
 
 	public Object getJavaObject(Literal l) {
 		IRI dt = l.getDatatype();
-		if ((dt == null) || XMLSchema.STRING.equals(dt)) {
+		if ((dt == null) || XSD.STRING.equals(dt)) {
 			return l.stringValue();
 		} 
-		else if (XMLSchema.BOOLEAN.equals(dt)) {
+		else if (XSD.BOOLEAN.equals(dt)) {
 			return l.booleanValue();
 		} 
-		else if (XMLSchema.INT.equals(dt)) {
+		else if (XSD.INT.equals(dt)) {
 			return l.intValue(); //Integer.valueOf(l.intValue());
 		} 
-		else if (XMLSchema.BYTE.equals(dt)) {
+		else if (XSD.BYTE.equals(dt)) {
 			return l.byteValue(); //Byte.valueOf(l.byteValue());
 		} 
-		else if (XMLSchema.LONG.equals(dt)) {
+		else if (XSD.LONG.equals(dt)) {
 			return l.longValue();//Long.valueOf(l.longValue());
 		} 
-		else if (XMLSchema.SHORT.equals(dt)) {
+		else if (XSD.SHORT.equals(dt)) {
 			return l.shortValue(); //Short.valueOf(l.shortValue());
 		} 
-		else if (XMLSchema.FLOAT.equals(dt)) {
+		else if (XSD.FLOAT.equals(dt)) {
 			return l.floatValue(); //Float.valueOf(l.floatValue());
 		} 
-		else if (XMLSchema.DOUBLE.equals(dt)) {
+		else if (XSD.DOUBLE.equals(dt)) {
 			return l.doubleValue();//Double.valueOf(l.doubleValue());
 		} 
-		else if (XMLSchema.DECIMAL.equals(dt)) {
+		else if (XSD.DECIMAL.equals(dt)) {
 			return l.decimalValue();
 		}
-		else if (XMLSchema.ANYURI.equals(dt)) {
+		else if (XSD.ANYURI.equals(dt)) {
 			return java.net.URI.create(l.stringValue());
 		}
-		else if (XMLSchema.DATETIME.equals(dt)) {
+		else if (XSD.DATETIME.equals(dt)) {
 			return l.calendarValue().toGregorianCalendar().getTime();
 		} 
-		else if (XMLSchema.DATE.equals(dt)) {
-			// TODO: Confirm this works for LocalDate
-			return l.temporalAccessorValue();
+		else if (XSD.DATE.equals(dt)) {
+			return LocalDate.from(l.temporalAccessorValue());
 		} 
 		else if (Java.CHAR.equals(dt)) {
 			String s = l.stringValue();
@@ -118,7 +119,7 @@ public class DefaultDatatypeMapper implements DatatypeMapper {
 		}
 		IRI dtUri = getDatatypeURI(value.getClass());
 		if (dtUri != null) {
-			if (dtUri.equals(XMLSchema.STRING)) {
+			if (dtUri.equals(XSD.STRING)) {
 				return vf.createLiteral(value.toString());
 			}
 			return vf.createLiteral(value.toString(), dtUri);

--- a/src/main/java/org/cyberborean/rdfbeans/impl/Unmarshaller.java
+++ b/src/main/java/org/cyberborean/rdfbeans/impl/Unmarshaller.java
@@ -89,7 +89,8 @@ public class Unmarshaller {
 			for (RDFProperty p : rbi.getProperties()) {
 				// Get values
 				IRI predicate = p.getUri();
-				CloseableIteration<Statement, ? extends RDF4JException> statements;
+				// CloseableIteration<Statement, ? extends RDF4JException> statements;
+				CloseableIteration<Statement> statements;
 				if (p.isInversionOfProperty()) {
 					statements = conn.getStatements(null, predicate, resource, false, (IRI)context);
 					if (!statements.hasNext()) {
@@ -254,7 +255,8 @@ public class Unmarshaller {
 	private Class<?> getBindingClass(RepositoryConnection conn, Resource r, Resource... contexts)
 			throws RDFBeanException, RepositoryException {
 		Class<?> cls = null;
-		try (CloseableIteration<Statement, RepositoryException> ts = conn.getStatements(r, RDF.TYPE, null, false, contexts)) {
+		//try (CloseableIteration<Statement, RepositoryException> ts = conn.getStatements(r, RDF.TYPE, null, false, contexts)) {
+		try (CloseableIteration<Statement> ts = conn.getStatements(r, RDF.TYPE, null, false, contexts)) {
 			while (cls == null && ts.hasNext()) {
 				Value type = ts.next().getObject();
 				if (type instanceof IRI) {

--- a/src/main/java/org/cyberborean/rdfbeans/impl/Unmarshaller.java
+++ b/src/main/java/org/cyberborean/rdfbeans/impl/Unmarshaller.java
@@ -20,7 +20,7 @@ import org.cyberborean.rdfbeans.reflect.RDFBeanInfo;
 import org.cyberborean.rdfbeans.reflect.RDFProperty;
 import org.cyberborean.rdfbeans.reflect.SubjectProperty;
 import org.cyberborean.rdfbeans.util.LockKeeper;
-import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;

--- a/src/main/java/org/cyberborean/rdfbeans/proxy/RDFBeanDelegator.java
+++ b/src/main/java/org/cyberborean/rdfbeans/proxy/RDFBeanDelegator.java
@@ -185,7 +185,8 @@ public class RDFBeanDelegator implements InvocationHandler {
 	private Object getValue(RDFProperty p) throws RDFBeanException, RepositoryException, RDF4JException {
 		RepositoryConnection conn = getRepositoryConnection();
 		Object result = null;
-		CloseableIteration<Statement, ? extends RDF4JException> sts;
+		//CloseableIteration<Statement, ? extends RDF4JException> sts;
+		CloseableIteration<Statement> sts;
 		if (p.isInversionOfProperty()) {
 			sts = conn.getStatements(null, p.getUri(), subject, false, (IRI)context);
 			if (!sts.hasNext()) {

--- a/src/main/java/org/cyberborean/rdfbeans/proxy/RDFBeanDelegator.java
+++ b/src/main/java/org/cyberborean/rdfbeans/proxy/RDFBeanDelegator.java
@@ -22,7 +22,7 @@ import org.cyberborean.rdfbeans.exceptions.RDFBeanException;
 import org.cyberborean.rdfbeans.exceptions.RDFBeanValidationException;
 import org.cyberborean.rdfbeans.reflect.RDFBeanInfo;
 import org.cyberborean.rdfbeans.reflect.RDFProperty;
-import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;

--- a/src/test/java/org/cyberborean/rdfbeans/datatype/DatatypeTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/datatype/DatatypeTest.java
@@ -3,6 +3,7 @@ package org.cyberborean.rdfbeans.datatype;
 import static org.junit.Assert.*;
 
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
@@ -35,6 +36,7 @@ public class DatatypeTest extends RDFBeansTestBase {
     	object.setLongValue(Long.MAX_VALUE);
     	object.setShortValue(Short.MAX_VALUE);
     	object.setDateValue(new Date());
+    	object.setLocalDate(LocalDate.now());
     	object.setUriValue(URI.create("http://rdfbeans.sourceforge.net"));
     	int[] array = new int[] {0, 1, 2, 3, 4};
     	object.setArrayValue(array);
@@ -67,6 +69,7 @@ public class DatatypeTest extends RDFBeansTestBase {
     	assertEquals(object.getLongValue(), object2.getLongValue());
     	assertEquals(object.getShortValue(), object2.getShortValue());
     	assertEquals(object.getDateValue(), object2.getDateValue());
+    	assertEquals(object.getLocalDate(), object2.getLocalDate());
     	assertEquals(object.getUriValue(), object2.getUriValue());
     	assertTrue(Arrays.equals(object.getArrayValue(), object2.getArrayValue()));
     	assertTrue(Arrays.equals(object.getListValue().toArray(), object2.getListValue().toArray()));

--- a/src/test/java/org/cyberborean/rdfbeans/datatype/ListTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/datatype/ListTest.java
@@ -2,11 +2,12 @@ package org.cyberborean.rdfbeans.datatype;
 
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -54,8 +55,9 @@ public class ListTest {
         assertThat(data, notNullValue());
         List list = data.getListValue();
         assertThat(list, notNullValue());
-        assertThat(list.size(), is(3));
-        assertThat(list.get(0), is(URI.class));
+        assertEquals(list.size(), 3);
+        assertEquals(list.get(0).getClass(), URI.class);
+        //assertThat(list.get(0), is(URI.class));
         assertThat((URI) list.get(0), equalTo(new URI("http://example.com/list/first")));
         assertThat((URI) list.get(list.size()-1), equalTo(new URI("http://example.com/list/last")));
     }
@@ -71,7 +73,8 @@ public class ListTest {
         try {
             assertTrue("A list statement is generated", listStatement.hasNext());
             Value object = listStatement.next().getObject();
-            assertThat(object, is(Resource.class));
+            assertThat(object, instanceOf(Resource.class));
+            //assertThat(object, is(Resource.class));
             assertTrue("Empty List encodes as 'L rdf:rest rdf:nil'", checkConn.hasStatement(
                     (Resource)object, // the blank node of the list head
                     RDF.REST,

--- a/src/test/java/org/cyberborean/rdfbeans/datatype/ListTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/datatype/ListTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.cyberborean.rdfbeans.RDFBeanManager;
 import org.cyberborean.rdfbeans.exceptions.RDFBeanException;
 import org.cyberborean.rdfbeans.test.entities.DatatypeTestClass;
-import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -40,7 +40,7 @@ public class ListTest {
     @Before
     public void setupManager() throws Exception {
         repo = new SailRepository(new MemoryStore());
-        repo.initialize();
+        // repo.initialize();
         RepositoryConnection initialFillConn = repo.getConnection();
         initialFillConn.add(getClass().getResourceAsStream("listUnmarshal.ttl"), "", RDFFormat.TURTLE);
         initialFillConn.close();

--- a/src/test/java/org/cyberborean/rdfbeans/test/RDFBeansTestBase.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/RDFBeansTestBase.java
@@ -20,7 +20,7 @@ public abstract class RDFBeansTestBase {
 	@Before
 	public void setupManager() throws Exception {
 		repo = new SailRepository(new MemoryStore());
-        repo.initialize();   
+        //repo.initialize();   
         manager = new RDFBeanManager(repo);
 	}
 	

--- a/src/test/java/org/cyberborean/rdfbeans/test/entities/DatatypeTestClass.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/entities/DatatypeTestClass.java
@@ -1,5 +1,6 @@
 package org.cyberborean.rdfbeans.test.entities;
 
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -31,6 +32,7 @@ public class DatatypeTestClass {
 	short shortValue;
 	Date dateValue;
 	java.net.URI uriValue;
+	LocalDate localDate;
 	
 	int[] arrayValue;
 	List<Object> listValue;
@@ -185,5 +187,20 @@ public class DatatypeTestClass {
 		this.sortedSetValue = sortedSetValue;
 	}
 	public void setHeadTailList(List<Object> headTailList) { this.headTailList = headTailList; }
+
+	/**
+	 * @return the localDate
+	 */
+	@RDF("http://cyberborean.org/rdfbeans/2.0/test/datatype/localdate")
+	public LocalDate getLocalDate() {
+		return localDate;
+	}
+
+	/**
+	 * @param localDate the localDate to set
+	 */
+	public void setLocalDate(LocalDate localDate) {
+		this.localDate = localDate;
+	}
 
 }

--- a/src/test/java/org/cyberborean/rdfbeans/test/examples/ExampleClassTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/examples/ExampleClassTest.java
@@ -108,7 +108,7 @@ public class ExampleClassTest extends RDFBeansTestBase {
     
     @Test
     public void testGetAll() throws Exception {                
-        CloseableIteration<Person, Exception> iter = manager.getAll(Person.class);
+        CloseableIteration<Person> iter = manager.getAll(Person.class);
         Set<Person> s = new HashSet<>();
         while (iter.hasNext()) {
             Object o = iter.next();

--- a/src/test/java/org/cyberborean/rdfbeans/test/foafexample/FOAFExampleTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/foafexample/FOAFExampleTest.java
@@ -127,7 +127,7 @@ public class FOAFExampleTest extends RDFBeansTestBase {
     
     @Test
     public void testGetAll() throws Exception {                
-    	CloseableIteration<Person, Exception> iter = manager.getAll(Person.class);
+    	CloseableIteration<Person> iter = manager.getAll(Person.class);
         Set<Person> s = new HashSet<>();
         while (iter.hasNext()) {
             Object o = iter.next();

--- a/src/test/java/org/cyberborean/rdfbeans/test/inversions/InversionsClass1Test.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/inversions/InversionsClass1Test.java
@@ -291,7 +291,7 @@ public class InversionsClass1Test extends RDFBeansTestBase  {
     	manager.close();
     	manager = new RDFBeanManager(repo);
     	
-    	CloseableIteration<Child, Exception> childIter = manager.getAll(Child.class);
+    	CloseableIteration<Child> childIter = manager.getAll(Child.class);
     	while (childIter.hasNext()) {
     		Parent p = childIter.next().getParent();
     		assertNull(p);

--- a/src/test/java/org/cyberborean/rdfbeans/test/inversions/InversionsClass2Test.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/inversions/InversionsClass2Test.java
@@ -290,7 +290,7 @@ public class InversionsClass2Test extends RDFBeansTestBase {
     	manager.close();
     	manager = new RDFBeanManager(repo);
     	
-    	CloseableIteration<Child, Exception> childIter = manager.getAll(Child.class);
+    	CloseableIteration<Child> childIter = manager.getAll(Child.class);
     	while (childIter.hasNext()) {
     		Parent p = childIter.next().getParent();
     		assertNull(p);

--- a/src/test/java/org/cyberborean/rdfbeans/test/namedgraphs/ExampleClassTest.java
+++ b/src/test/java/org/cyberborean/rdfbeans/test/namedgraphs/ExampleClassTest.java
@@ -141,14 +141,14 @@ public class ExampleClassTest extends RDFBeansTestBase {
 		_testGetAll(graph1);
 		_testGetAll(graph2);
 		
-		CloseableIteration<Person, Exception> iter = manager.getContext(graph0).getAll(Person.class);
+		CloseableIteration<Person> iter = manager.getContext(graph0).getAll(Person.class);
 		assertFalse(iter.hasNext());
 		iter.close();
 		
 	}
 	
 	private void _testGetAll(IRI graph) throws Exception {
-		CloseableIteration<Person, Exception> iter = manager.getContext(graph).getAll(Person.class);
+		CloseableIteration<Person> iter = manager.getContext(graph).getAll(Person.class);
 		Set<Person> s = new HashSet<>();
 		while (iter.hasNext()) {
 			Object o = iter.next();


### PR DESCRIPTION
Updating pom to rdf4j 4.3.8 (and current slf4j 2.0.9).  With RDF4j 4.0, RDF4JException moved, updating references to new path: org.eclipse.rdf4j.common.exception.RDF4JException.  Also commenting out invocations of initialize() on SailRepository as Repository class no longer has an exposed initialized method.  A project using rdfbeans was getting transitive vulnerability warnings from maven central on release, arising from rdfbeans depending on rdf4j 2.2, which itself had a dependency  on a library  using CVE-2020-15250.  Solution is to move to current rdf4j release, but between version 2 and version 4, rdf4j changed the API.  This pull request updates the dependencies and addresses the (minor) changes in the rd4j API.